### PR TITLE
Add Windfinder Home Assistant integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
-# ha_wf
+# Windfinder Home Assistant Integration
+
+This repository contains a custom integration and Lovelace card to display wind conditions from Windfinder using a Node-RED backend.
+
+## Installation
+
+1. Copy this repository into your Home Assistant `config` directory so the structure looks like `custom_components/windfinder` and `www/windfinder-card.js`.
+2. Restart Home Assistant.
+3. Use HACS or the integrations page to add **Windfinder** and follow the setup flow to configure your location and Node-RED endpoint.
+4. Add the `windfinder-card` to your dashboard and select the sensor entity.
+
+## Development
+
+The backend fetches data from the Node-RED endpoint specified during configuration. The frontend card displays speed, direction and gust values provided by the sensor entity.

--- a/custom_components/windfinder/.translations/en.json
+++ b/custom_components/windfinder/.translations/en.json
@@ -1,0 +1,17 @@
+{
+    "config": {
+        "step": {
+            "user": {
+                "title": "Configure Windfinder",
+                "description": "Set your location and Node-RED endpoint.",
+                "data": {
+                    "location": "Location",
+                    "endpoint": "Node-RED endpoint"
+                }
+            },
+            "init": {
+                "title": "Windfinder Options"
+            }
+        }
+    }
+}

--- a/custom_components/windfinder/__init__.py
+++ b/custom_components/windfinder/__init__.py
@@ -1,0 +1,67 @@
+"""Windfinder integration."""
+
+from __future__ import annotations
+
+import logging
+
+from datetime import timedelta
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import aiohttp_client
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+
+from .const import DOMAIN, CONF_ENDPOINT, CONF_LOCATION, DEFAULT_ENDPOINT, PLATFORMS
+
+_LOGGER = logging.getLogger(__name__)
+
+async def async_setup(hass: HomeAssistant, config: dict) -> bool:
+    """Set up the Windfinder component."""
+    return True
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up Windfinder from a config entry."""
+    hass.data.setdefault(DOMAIN, {})
+
+    session = aiohttp_client.async_get_clientsession(hass)
+
+    coordinator = WindfinderDataUpdateCoordinator(
+        hass,
+        session=session,
+        endpoint=entry.data.get(CONF_ENDPOINT, DEFAULT_ENDPOINT),
+        location=entry.data[CONF_LOCATION],
+    )
+    await coordinator.async_config_entry_first_refresh()
+
+    hass.data[DOMAIN][entry.entry_id] = coordinator
+
+    hass.config_entries.async_setup_platforms(entry, PLATFORMS)
+
+    return True
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload a config entry."""
+    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+    if unload_ok:
+        hass.data[DOMAIN].pop(entry.entry_id)
+    return unload_ok
+
+class WindfinderDataUpdateCoordinator(DataUpdateCoordinator):
+    """Class to manage fetching data from Node-RED."""
+
+    def __init__(self, hass, *, session, endpoint, location):
+        """Initialize coordinator."""
+        super().__init__(hass, _LOGGER, name=DOMAIN, update_interval=timedelta(minutes=5))
+        self._session = session
+        self._endpoint = endpoint
+        self._location = location
+
+    async def _async_update_data(self):
+        """Fetch data from Node-RED."""
+        try:
+            url = f"{self._endpoint}?location={self._location}"
+            async with self._session.get(url, timeout=10) as resp:
+                resp.raise_for_status()
+                return await resp.json()
+        except Exception as err:
+            raise UpdateFailed(err)

--- a/custom_components/windfinder/config_flow.py
+++ b/custom_components/windfinder/config_flow.py
@@ -1,0 +1,54 @@
+"""Config flow for Windfinder integration."""
+
+from __future__ import annotations
+
+import voluptuous as vol
+
+from homeassistant import config_entries
+from homeassistant.core import callback
+
+from .const import DOMAIN, CONF_LOCATION, CONF_ENDPOINT, DEFAULT_ENDPOINT
+
+class WindfinderConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for Windfinder."""
+
+    VERSION = 1
+
+    async def async_step_user(self, user_input=None):
+        if user_input is not None:
+            return self.async_create_entry(title=user_input[CONF_LOCATION], data=user_input)
+
+        return self.async_show_form(
+            step_id="user",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(CONF_LOCATION): str,
+                    vol.Optional(CONF_ENDPOINT, default=DEFAULT_ENDPOINT): str,
+                }
+            ),
+        )
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(config_entry):
+        return WindfinderOptionsFlowHandler(config_entry)
+
+class WindfinderOptionsFlowHandler(config_entries.OptionsFlow):
+    """Handle options flow."""
+
+    def __init__(self, config_entry):
+        self.config_entry = config_entry
+
+    async def async_step_init(self, user_input=None):
+        if user_input is not None:
+            return self.async_create_entry(title="", data=user_input)
+
+        return self.async_show_form(
+            step_id="init",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(CONF_LOCATION, default=self.config_entry.data.get(CONF_LOCATION)): str,
+                    vol.Optional(CONF_ENDPOINT, default=self.config_entry.data.get(CONF_ENDPOINT, DEFAULT_ENDPOINT)): str,
+                }
+            ),
+        )

--- a/custom_components/windfinder/const.py
+++ b/custom_components/windfinder/const.py
@@ -1,0 +1,5 @@
+DOMAIN = "windfinder"
+CONF_LOCATION = "location"
+CONF_ENDPOINT = "endpoint"
+DEFAULT_ENDPOINT = "http://localhost:1880/windfinder"  # Example Node-RED endpoint
+PLATFORMS = ["sensor"]

--- a/custom_components/windfinder/manifest.json
+++ b/custom_components/windfinder/manifest.json
@@ -1,0 +1,10 @@
+{
+    "domain": "windfinder",
+    "name": "Windfinder",
+    "documentation": "https://github.com/example/windfinder",
+    "version": "0.1.0",
+    "config_flow": true,
+    "requirements": [],
+    "codeowners": ["@yourname"],
+    "iot_class": "cloud_polling"
+}

--- a/custom_components/windfinder/sensor.py
+++ b/custom_components/windfinder/sensor.py
@@ -1,0 +1,44 @@
+"""Windfinder sensors."""
+
+from __future__ import annotations
+
+from homeassistant.components.sensor import SensorEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import DOMAIN, CONF_LOCATION
+
+SENSOR_TYPES = {
+    "speed": ["Wind Speed", "m/s"],
+    "direction": ["Wind Direction", "°"],
+    "gust": ["Wind Gust", "m/s"],
+}
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+) -> None:
+    coordinator = hass.data[DOMAIN][entry.entry_id]
+    entities = [WindfinderSensor(coordinator, key) for key in SENSOR_TYPES]
+    async_add_entities(entities)
+
+class WindfinderSensor(SensorEntity):
+    """Representation of a Windfinder sensor."""
+
+    def __init__(self, coordinator, sensor_type: str):
+        self.coordinator = coordinator
+        self._attr_name = SENSOR_TYPES[sensor_type][0]
+        self._attr_unit_of_measurement = SENSOR_TYPES[sensor_type][1]
+        self._sensor_type = sensor_type
+
+    @property
+    def available(self) -> bool:
+        return self.coordinator.last_update_success
+
+    async def async_update(self):
+        await self.coordinator.async_request_refresh()
+
+    @property
+    def state(self):
+        data = self.coordinator.data or {}
+        return data.get(self._sensor_type)

--- a/www/windfinder-card.js
+++ b/www/windfinder-card.js
@@ -1,0 +1,36 @@
+class WindfinderCard extends HTMLElement {
+  setConfig(config) {
+    if (!config.entity) {
+      throw new Error('Entity required');
+    }
+    this.config = config;
+  }
+
+  set hass(hass) {
+    const entity = hass.states[this.config.entity];
+    if (!entity) return;
+    this.innerHTML = `
+      <ha-card header="Windfinder">
+        <div class="card-content">
+          <div>Speed: ${entity.attributes.speed} m/s</div>
+          <div>Direction: ${entity.attributes.direction}°</div>
+          <div>Gust: ${entity.attributes.gust} m/s</div>
+        </div>
+      </ha-card>
+    `;
+  }
+
+  getCardSize() {
+    return 1;
+  }
+}
+
+customElements.define('windfinder-card', WindfinderCard);
+
+window.customCards = window.customCards || [];
+window.customCards.push({
+  type: 'windfinder-card',
+  name: 'Windfinder Card',
+  preview: true,
+  description: 'Shows wind conditions from Windfinder.'
+});


### PR DESCRIPTION
## Summary
- implement a simple custom integration for Home Assistant that fetches wind data via a Node-RED endpoint
- expose configuration for the location and endpoint through config flow
- provide a Lovelace card to display the wind data

## Testing
- `python -m py_compile custom_components/windfinder/*.py`
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_684c329169fc8328886a61e623fb9f4e