### PR TITLE
Fix hour parsing with trailing 'h'

### DIFF
--- a/custom_components/windfinder/__init__.py
+++ b/custom_components/windfinder/__init__.py
@@ -156,7 +156,11 @@ def _parse_html(html: str, url: str, forecast_type: str) -> dict:
             speed_el = row.select_one(".cell-wind-3 .units-ws")
             if not hour_el or not speed_el:
                 continue
-            hour = int(hour_el.text.strip())
+            hour_text = hour_el.text.strip()
+            m = re.search(r"(\d+)", hour_text)
+            if not m:
+                continue
+            hour = int(m.group(1))
             dt = datetime(year, month, day_num, hour)
 
             gust_el = row.select_one(".cell-wind-3 .data-gusts .units-ws")


### PR DESCRIPTION
## Summary
- robustify hour parsing in Windfinder integration

## Testing
- `python -m py_compile custom_components/windfinder/__init__.py`

------
https://chatgpt.com/codex/tasks/task_e_684c3d647d748328a47f2cc3d9b23daa