### PR TITLE
Remove unused attributes and ensure UTC datetimes

### DIFF
--- a/custom_components/windfinder/sensor.py
+++ b/custom_components/windfinder/sensor.py
@@ -53,7 +53,4 @@ class WindfinderSensor(SensorEntity):
             attrs["superforecastdata"] = data["superforecastdata"]
         if "general" in data:
             attrs.update(data["general"])
-        attrs["speed"] = data.get("speed")
-        attrs["direction"] = data.get("direction")
-        attrs["gust"] = data.get("gust")
         return attrs


### PR DESCRIPTION
## Summary
- treat parsed dates as timezone-aware UTC
- drop `speed`, `direction`, and `gust` attributes from sensor data

## Testing
- `python -m py_compile custom_components/windfinder/*.py`

------
https://chatgpt.com/codex/tasks/task_e_684c98075ba8832887a50240300b522e