### PR TITLE
Add configurable refresh interval

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ This repository contains a custom integration that displays wind conditions from
 2. Restart Home Assistant.
 3. Use HACS or the integrations page to add **Windfinder** and follow the setup flow to configure your location.
 
+The integration refreshes data every 30 minutes by default. The update frequency
+can be adjusted later via the integration options in Home Assistant.
+
 ## Development
 
 The backend fetches data directly from windfinder.com based on the configured

--- a/custom_components/windfinder/config_flow.py
+++ b/custom_components/windfinder/config_flow.py
@@ -10,8 +10,8 @@ from homeassistant.core import callback
 from .const import (
     DOMAIN,
     CONF_LOCATION,
-    CONF_INITIAL_REFRESH,
-    DEFAULT_INITIAL_REFRESH,
+    CONF_REFRESH_INTERVAL,
+    DEFAULT_REFRESH_INTERVAL,
 )
 
 class WindfinderConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
@@ -51,9 +51,9 @@ class WindfinderOptionsFlowHandler(config_entries.OptionsFlow):
                         CONF_LOCATION, default=self.config_entry.data.get(CONF_LOCATION)
                     ): str,
                     vol.Required(
-                        CONF_INITIAL_REFRESH,
+                        CONF_REFRESH_INTERVAL,
                         default=self.config_entry.options.get(
-                            CONF_INITIAL_REFRESH, DEFAULT_INITIAL_REFRESH
+                            CONF_REFRESH_INTERVAL, DEFAULT_REFRESH_INTERVAL
                         ),
                     ): int,
                 }

--- a/custom_components/windfinder/const.py
+++ b/custom_components/windfinder/const.py
@@ -4,5 +4,5 @@ FORECAST_URL = "https://www.windfinder.com/forecast/{}"
 SUPERFORECAST_URL = "https://www.windfinder.com/weatherforecast/{}"
 PLATFORMS = ["sensor"]
 
-CONF_INITIAL_REFRESH = "initial_refresh"
-DEFAULT_INITIAL_REFRESH = 5  # hours
+CONF_REFRESH_INTERVAL = "refresh_interval"
+DEFAULT_REFRESH_INTERVAL = 30  # minutes

--- a/custom_components/windfinder/manifest.json
+++ b/custom_components/windfinder/manifest.json
@@ -2,7 +2,7 @@
     "domain": "windfinder",
     "name": "Windfinder",
     "documentation": "https://github.com/example/windfinder",
-    "version": "0.5.0",
+    "version": "0.6.0",
     "config_flow": true,
     "requirements": ["beautifulsoup4>=4.13.0"],
     "codeowners": ["@yourname"],


### PR DESCRIPTION
## Summary
- allow configuring one refresh interval via integration options
- bump manifest version

## Testing
- `python -m py_compile custom_components/windfinder/*.py`
- `flake8 custom_components/windfinder 2>&1 | head -n 20` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d1dfcb5a48328be4ac925e3be35f8