### PR TITLE
Add manual refresh button

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ can be adjusted later via the integration options in Home Assistant.
 The backend fetches data directly from windfinder.com based on the configured
 location. Each configured location creates a device with a single sensor named
 after the location (for example `sensor.hawf_noordwijk`). The sensor's state is
-the timestamp of the last update reported on Windfinder. All timestamps are now
+the timestamp of the last update reported on Windfinder. A refresh button is
+also added for each device so data can be fetched on demand. All timestamps are
 converted to UTC. Forecast data and current conditions are stored in the
 sensor's attributes for further use.

--- a/custom_components/windfinder/button.py
+++ b/custom_components/windfinder/button.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from homeassistant.components.button import ButtonEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import DOMAIN, CONF_LOCATION
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+) -> None:
+    coordinator = hass.data[DOMAIN][entry.entry_id]
+    async_add_entities([WindfinderRefreshButton(coordinator, entry)])
+
+
+class WindfinderRefreshButton(ButtonEntity):
+    """Button entity to manually refresh Windfinder data."""
+
+    _attr_should_poll = False
+
+    def __init__(self, coordinator, entry: ConfigEntry) -> None:
+        self.coordinator = coordinator
+        location = entry.data[CONF_LOCATION]
+        self._attr_name = f"Refresh Windfinder {location}"
+        self._attr_unique_id = f"{entry.entry_id}_refresh"
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, entry.entry_id)},
+            name=f"Windfinder {location}",
+            manufacturer="Windfinder",
+        )
+
+    @property
+    def available(self) -> bool:
+        return self.coordinator.last_update_success
+
+    async def async_press(self) -> None:
+        await self.coordinator.async_request_refresh()

--- a/custom_components/windfinder/const.py
+++ b/custom_components/windfinder/const.py
@@ -2,7 +2,7 @@ DOMAIN = "windfinder"
 CONF_LOCATION = "location"
 FORECAST_URL = "https://www.windfinder.com/forecast/{}"
 SUPERFORECAST_URL = "https://www.windfinder.com/weatherforecast/{}"
-PLATFORMS = ["sensor"]
+PLATFORMS = ["sensor", "button"]
 
 CONF_REFRESH_INTERVAL = "refresh_interval"
 DEFAULT_REFRESH_INTERVAL = 30  # minutes

--- a/custom_components/windfinder/manifest.json
+++ b/custom_components/windfinder/manifest.json
@@ -2,7 +2,7 @@
     "domain": "windfinder",
     "name": "Windfinder",
     "documentation": "https://github.com/example/windfinder",
-    "version": "0.6.0",
+    "version": "0.7.0",
     "config_flow": true,
     "requirements": ["beautifulsoup4>=4.13.0"],
     "codeowners": ["@yourname"],


### PR DESCRIPTION
## Summary
- add `button` platform for manual data refresh
- bump integration version to 0.7.0
- document new refresh feature

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684d63a019548328985906251b05cdc6