### PR TITLE
Add refresh service

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,16 @@ The sensor exposes the following attributes:
 - `superforecast_generated` / `superforecast_fetched` provide the same
   timestamps for the superforecast.
 - `spot_name` contains the name of the location as reported by Windfinder.
+
+## Refresh Service
+
+In addition to the refresh button entity, the integration exposes a service
+`windfinder.refresh` to trigger an immediate update. Provide the `location`
+exactly as configured when calling the service. This can be used in
+automations or scripts. Example:
+
+```yaml
+service: windfinder.refresh
+data:
+  location: hawf_noordwijk
+```


### PR DESCRIPTION
## Summary
- add `windfinder.refresh` service to refresh data for a location
- document service usage in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6854568627548328ae8f648b084f0ab5