### PR TITLE
Set state to latest generated forecast time

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,10 @@ can be adjusted later via the integration options in Home Assistant.
 
 The backend fetches data directly from windfinder.com based on the configured
 location. Each configured location creates a device with a single sensor named
-after the location (for example `sensor.hawf_noordwijk`). The sensor's state is
-the timestamp of the last update reported on Windfinder. A refresh button is
-also added for each device so data can be fetched on demand. All timestamps are
+after the location (for example `sensor.hawf_noordwijk`). The sensor's state
+shows when the data was generated and is determined by whichever is the latest
+of `forecast_generated` or `superforecast_generated`. A refresh button is also
+added for each device so data can be fetched on demand. All timestamps are
 converted to UTC. Forecast data and current conditions are stored in the
 sensor's attributes for further use.
 

--- a/custom_components/windfinder/manifest.json
+++ b/custom_components/windfinder/manifest.json
@@ -2,7 +2,7 @@
     "domain": "windfinder",
     "name": "Windfinder",
     "documentation": "https://github.com/example/windfinder",
-    "version": "0.7.0",
+    "version": "0.7.1",
     "config_flow": true,
     "requirements": ["beautifulsoup4>=4.13.0"],
     "codeowners": ["@jtonk"],

--- a/custom_components/windfinder/sensor.py
+++ b/custom_components/windfinder/sensor.py
@@ -8,6 +8,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from datetime import datetime
 
 from .const import DOMAIN, CONF_LOCATION
 
@@ -44,7 +45,23 @@ class WindfinderSensor(CoordinatorEntity, SensorEntity):
     @property
     def state(self):
         data = self.coordinator.data or {}
-        return data.get("superforecast_generated") or data.get("forecast_generated")
+        forecast_generated = data.get("forecast_generated")
+        superforecast_generated = data.get("superforecast_generated")
+
+        latest_dt = None
+        for ts in (forecast_generated, superforecast_generated):
+            if ts:
+                try:
+                    dt = datetime.fromisoformat(ts)
+                    if not latest_dt or dt > latest_dt:
+                        latest_dt = dt
+                except ValueError:
+                    pass
+
+        if latest_dt:
+            return latest_dt.isoformat()
+
+        return superforecast_generated or forecast_generated
 
     @property
     def extra_state_attributes(self):


### PR DESCRIPTION
## Summary
- show later of forecast and superforecast generation times in sensor state
- clarify docs about sensor state
- bump integration version to 0.7.1

## Testing
- `python -m py_compile custom_components/windfinder/sensor.py`
- `python -m py_compile custom_components/windfinder/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6857d8542cf88328bb23ed81b34144e1