### PR TITLE
Add windsock icon to sensor

### DIFF
--- a/custom_components/windfinder/sensor.py
+++ b/custom_components/windfinder/sensor.py
@@ -26,6 +26,7 @@ class WindfinderSensor(CoordinatorEntity, SensorEntity):
     """Representation of a Windfinder sensor for one location."""
 
     _attr_should_poll = False
+    _attr_icon = "mdi:windsock"
 
     def __init__(self, coordinator, entry: ConfigEntry):
         super().__init__(coordinator)


### PR DESCRIPTION
## Summary
- set icon for Windfinder sensor using `mdi:windsock`

## Testing
- `pre-commit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859d5006c748328bfbcf2eeb8e13e54