### PR TITLE
Fix config flow handler name

### DIFF
--- a/custom_components/windfinder/config_flow.py
+++ b/custom_components/windfinder/config_flow.py
@@ -15,7 +15,7 @@ from .const import (
 )
 
 
-class WindfinderConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Windfinder."""
 
     VERSION = 1


### PR DESCRIPTION
## Summary
- ensure config flow class uses expected ConfigFlow name for Home Assistant

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b9d524d29c8328999bb71fbf669e03