### PR TITLE
Add Windfinder refresh service description

### DIFF
--- a/custom_components/windfinder/manifest.json
+++ b/custom_components/windfinder/manifest.json
@@ -1,8 +1,8 @@
 {
     "domain": "windfinder",
     "name": "Windfinder",
-    "documentation": "https://github.com/example/windfinder",
-    "version": "0.7.4",
+    "documentation": "https://github.com/jtonk/ha_wf",
+    "version": "0.7.5",
     "config_flow": true,
     "requirements": ["beautifulsoup4>=4.13.0"],
     "codeowners": ["@jtonk"],

--- a/custom_components/windfinder/services.yaml
+++ b/custom_components/windfinder/services.yaml
@@ -1,0 +1,12 @@
+refresh:
+  name: Refresh
+  description: Refresh Windfinder forecast data immediately.
+  fields:
+    entity_id:
+      name: Entity
+      description: Windfinder entities to refresh.
+      required: true
+      selector:
+        entity:
+          integration: windfinder
+          multiple: true


### PR DESCRIPTION
## What changed

- Add `custom_components/windfinder/services.yaml` for the existing `windfinder.refresh` action.
- Restrict the entity selector to Windfinder entities and allow multiple selections.
- Bump the integration version from `0.7.4` to `0.7.5`.
- Replace the placeholder documentation URL with this repository.

## Why

Windfinder registers `windfinder.refresh` in `__init__.py`, but the repository did not include a matching service description. Home Assistant 2026.8.1 consequently logged:

```
Failed to load services.yaml for integration: windfinder
```

The integration continued loading, but its refresh action lacked metadata in Home Assistant's action UI.

## Validation

- Parsed the new service definition successfully with the YAML parser bundled in the running Home Assistant 2026.8.1 container.
- Parsed and checked the updated manifest successfully as JSON.
- Confirmed the branch is two commits ahead of `main` and changes only `manifest.json` and the new `services.yaml`.